### PR TITLE
fix(nav): ahora la nav tiene mas estados activos

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -28,7 +28,16 @@ const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
   <div id="nav-links">
     {
       navLinks.map(({ link, label }) => (
-        <a href={link} class:list={[{ active: currentPath === link }]}>
+        <a
+          href={link}
+          class:list={[
+            {
+              // se muestra activo si el link es o empieza con algunos de los navLinks
+              active:
+                currentPath === link || currentPath.startsWith(link + "/"),
+            },
+          ]}
+        >
           {label}
         </a>
       ))


### PR DESCRIPTION
La nav tenía una regla CSS para señalar la pestaña en la que te encontraras; sin embargo, esta feature la implementé cuando cada navLink era una página distinta. Ahora recursos es un índice con subpáginas dentro. Esto causaba que, por ejemplo, /recursos se viera resaltado, pero /recursos/temario no. No considero que ese sea el comportamiento adecuado; los usuarios deben tener conocimiento de qué sección se encuentran, independientemente de si es una página o una sección de páginas.